### PR TITLE
Add rarity colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "ethers": "^5.4.6",
     "lodash": "^4.17.21",
+    "loot-rarity": "^3.0.0",
     "next": "latest",
     "p-map": "^5.1.0",
     "react": "^17.0.2",

--- a/pages/api/robes/index.ts
+++ b/pages/api/robes/index.ts
@@ -54,25 +54,20 @@ export interface RobeInfo {
 export const fetchRobes = async () => {
   const data = await pMap(chunked, fetchRobePage, { concurrency: 2 })
   const mapped = flatten(data)
-    .filter((d) => {
-      return (
-        d.sell_orders &&
-        d.sell_orders.length > 0 &&
-        d.sell_orders[0].payment_token_contract.symbol == 'ETH'
-      )
-    })
+    .filter((d) => d?.sell_orders?.[0]?.payment_token_contract.symbol === 'ETH')
     .map((a: Asset): RobeInfo => {
       return {
         id: a.token_id,
         price: Number(
           etherUtils.formatUnits(
-            BigNumber.from(a.sell_orders[0].current_price.split('.')[0]),
+            BigNumber.from(a.sell_orders[0]?.current_price.split('.')[0]),
           ),
         ),
         url: a.permalink + '?ref=0xfb843f8c4992efdb6b42349c35f025ca55742d33',
         svg: a.image_url,
       }
     })
+
   return {
     robes: orderBy(mapped, ['price', 'id'], ['asc', 'asc']),
     lastUpdate: new Date().toISOString(),

--- a/pages/api/robes/index.ts
+++ b/pages/api/robes/index.ts
@@ -2,11 +2,28 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import pMap from 'p-map'
 import { chunk, flatten, orderBy } from 'lodash'
 import { utils as etherUtils, BigNumber } from 'ethers'
+import { rarityImage } from 'loot-rarity'
 import type { OpenseaResponse, Asset } from '../../../utils/openseaTypes'
 import RobeIDs from '../../../data/robes-ids.json'
 
 const chunked = chunk(RobeIDs, 20)
 const apiKey = process.env.OPENSEA_API_KEY
+
+const imageCache = new Map()
+
+const fetchSvgRarity = async ({ image_url, token_id }) => {
+  if (!imageCache.has(token_id)) {
+    console.log(`${token_id} not in cache. Caching…`)
+    imageCache.set(
+      token_id,
+      await rarityImage(image_url, {
+        colorFn: ({ itemName }) =>
+          itemName.toLowerCase().includes('divine robe') && 'cyan',
+      }),
+    )
+  }
+  return imageCache.get(token_id)
+}
 
 const fetchRobePage = async (ids: string[]) => {
   let url = 'https://api.opensea.io/api/v1/assets?collection=lootproject&'
@@ -18,7 +35,13 @@ const fetchRobePage = async (ids: string[]) => {
     },
   })
   const json: OpenseaResponse = await res.json()
-  return json.assets
+
+  return Promise.all(
+    json.assets.map(async (asset) => ({
+      ...asset,
+      image_url: await fetchSvgRarity(asset),
+    })),
+  )
 }
 
 export interface RobeInfo {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,7 +21,7 @@ const Robe = ({ robe }: { robe: RobeInfo }) => {
   return (
     <a href={robe.url} target="_blank">
       <div className="m-auto pb-4 mb-8 flex flex-col justify-center items-center gap-2 p-4 md:m-4 border border-white transform hover:scale-105 transition-all bg-black w-full md:w-96">
-        <img src={robe.svg} />
+        <img src={robe.svg} alt="" width="350" height="350" />
         <div className="text-center">
           <p className="text-lg">#{robe.id}</p>
           <p>{robe.price} ETH</p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,6 +1742,14 @@ isarray@^1.0.0, isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
 jest-worker@27.0.0-next.5:
   version "27.0.0-next.5"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.0.0-next.5.tgz#5985ee29b12a4e191f4aae4bb73b97971d86ec28"
@@ -1829,6 +1837,13 @@ loose-envify@^1.1.0:
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+loot-rarity@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/loot-rarity/-/loot-rarity-3.0.0.tgz#6c3b0bd1c326d8bff15c3bfb155d4a4c34eebf90"
+  integrity sha512-iOuP2+dleTLhet976k/2P5nyiiCJmOGsn0kEwUXozbKGAgRel1DXFrC/dzqy6YCIiHXprU4HH2/2DwSQrFod5Q==
+  dependencies:
+    isomorphic-fetch "^3.0.0"
 
 make-dir@^3.0.2:
   version "3.1.0"
@@ -1979,7 +1994,7 @@ node-emoji@^1.11.0:
   dependencies:
     lodash "^4.17.21"
 
-node-fetch@2.6.1:
+node-fetch@2.6.1, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -2953,6 +2968,11 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-url@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
This PR adds rarity levels to card images using [loot-rarity](https://github.com/bpierre/loot-rarity). I made Divine Robes appear in cyan, but feel free to change this to anything else of course.

The images are cached so that we don’t need to fetch them every time. There are not that many so I don’t think keeping them in cache would be an issue. An alternative would be to decode the data URI of the JSON to pass the source SVG without fetching anything else, let me know if you prefer doing that.

![image](https://user-images.githubusercontent.com/36158/131594933-94f735a3-62dc-47f3-b711-b251f7d0ba8f.png)
